### PR TITLE
fix: stop printing completion request errors

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -109,7 +109,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 
 connection.onDocumentFormatting(
 	(params: DocumentFormattingParams): TextEdit[] => {
-		let tabSize = params.options.tabSize
+		let tabSize = params.options.tabSize;
 		let documentText: string = document.getText();
 		let reader = ion.makeReader(documentText);
 		let writer = ion.makePrettyWriter(tabSize);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -44,6 +44,7 @@ documents.onDidClose(e => {
 	connection.sendDiagnostics({ uri: e.document.uri, diagnostics });
 });
 
+// On completion, do nothing. This is needed to suppress errors.
 connection.onCompletion((_textDocumentPosition) => { return [] });
 
 // custom implementation of ANTLR's ErrorListener


### PR DESCRIPTION
Issue #, if available:
Closes #78 

Description of changes:

1. Stops printing errors due to missing completion method 
1. Passes the tabSize value  onfigured in  VSCode to formatting action in ion-js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

