### PR TITLE
Add Development note about configuring `node-gyp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     
 ## Development 
 
+- This project transitively uses [`node-gyp`](https://github.com/nodejs/node-gyp), so see configuration instructions for your platform there.
 - Run `npm install` in this folder. This installs all necessary npm modules in both the client and server folder
 - Open VS Code on this folder.
 - Press Ctrl+Shift+B to compile the client and server.


### PR DESCRIPTION
Without configuration for `node-gyp` the `npm install` step for this project can fail. 

Issue #, if available: #81

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

